### PR TITLE
Better error handling.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-contrib-json-schema",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "description": "JSON Schema validator for Node Red",
     "main": "index.js",
     "scripts": {

--- a/schema.html
+++ b/schema.html
@@ -1,9 +1,8 @@
 <script type="text/javascript">
-    /*global RED*/
     RED.nodes.registerType('json-schema', {
         category: 'function',
         inputs: 1,
-        outputs: 1,
+        outputs: 2,
         color: "#debd5c",
         icon: "function.png",
         paletteLabel: "json schema",


### PR DESCRIPTION
1. Remove debug logs
2. ES6 syntax for current LTS
3. Send errors to 2nd output
4. Catch malformed schemas